### PR TITLE
Fix Controller Errors

### DIFF
--- a/skeleton.routing.yml
+++ b/skeleton.routing.yml
@@ -1,7 +1,7 @@
 skeleton.author:
   path: '/system/ajax/skeleton_test'
   defaults:
-    _controller: 'Drupal\skeleton\Controller\SkeletonController::content'
+    _controller: '\Drupal\skeleton\Controller\SkeletonController::content'
     _title: 'Skeleton Controller'
   requirements:
     _permission: 'access content'

--- a/src/Controller/SkeletonController.php
+++ b/src/Controller/SkeletonController.php
@@ -12,7 +12,7 @@ namespace Drupal\skeleton\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\views\Views;
 
-class skeletonController extends ControllerBase {
+class SkeletonController extends ControllerBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
- Fix the missing \ in front of "Drupal\skeleton\..." the routing file
- Fix the spelling of the Controller Class Name